### PR TITLE
fix clonechildwithprops when child is null

### DIFF
--- a/src/Stage.js
+++ b/src/Stage.js
@@ -16,7 +16,7 @@ class Stage extends Container {
     return (
         <div>
           <div ref="canvas"></div>
-          {React.Children.map(this.props.children, child => React.addons.cloneWithProps(child))}
+          {React.Children.map(this.props.children, child => child ? React.addons.cloneWithProps(child) : null)}
         </div>
     );
   }

--- a/src/abstract/Container.js
+++ b/src/abstract/Container.js
@@ -23,7 +23,7 @@ class Container extends Base {
   render() {
     return (
       <span>
-        {React.Children.map(this.props.children, child => React.addons.cloneWithProps(child))}
+        {React.Children.map(this.props.children, child => child ? React.addons.cloneWithProps(child) : null)}
       </span>
     );
   }


### PR DESCRIPTION
When jsx contains null components child must not be cloned.
Fixes :
"cannot read property ref of undefined."